### PR TITLE
Fix create initial user migration dependencies

### DIFF
--- a/api/paul_api/api/migrations/0047_auto_20220525_1218.py
+++ b/api/paul_api/api/migrations/0047_auto_20220525_1218.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('api', '0046_auto_20211206_1958'),
-        ('auth', '0008_alter_user_username_max_length'),
+        ('auth', '0012_alter_user_first_name_max_length'),
     ]
 
     operations = [


### PR DESCRIPTION
The admin user is now created after all (current) `auth` migrations are applied.

New default Django `max_length` are 150 chars for Group name, User username, User first_name, User last_name.